### PR TITLE
Update next to 15.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dropbox": "^10.34.0",
     "eslint": "9.32.0",
     "eslint-config-next": "15.4.4",
-    "next": "15.4.4",
+    "next": "15.4.8",
     "postcss": "8.5.6",
     "react": "19.1.1",
     "react-dom": "19.1.1",


### PR DESCRIPTION
A critical vulnerability in React Server Components (CVE-2025-55182) has been responsibly disclosed. It affects React 19 and frameworks that use it, including Next.js (CVE-2025-66478).

If you are using Next.js, every version between Next.js 15 and 16 is affected, and we recommend immediately updating to the latest Next.js versions containing the appropriate fixes (15.0.5, 15.1.9, 15.2.6, 15.3.6, 15.4.8, 15.5.7, 16.0.7).